### PR TITLE
Incorperate feedback

### DIFF
--- a/.github/tests/upstream-authority-cert-manager/values.yaml
+++ b/.github/tests/upstream-authority-cert-manager/values.yaml
@@ -2,4 +2,5 @@ spire-server:
   upstreamAuthority:
     certManager:
       enabled: true
-      createCA: true
+      ca:
+        create: true

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -306,11 +306,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.controllerManager.service.port | int | `443` |  |
 | spire-server.controllerManager.service.type | string | `"ClusterIP"` |  |
 | spire-server.controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `""` | Overrides the image tag |
-| spire-server.controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | spire-server.dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | spire-server.dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -382,6 +377,11 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | spire-server.telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-server |
 | spire-server.tolerations | list | `[]` |  |
+| spire-server.tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| spire-server.tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| spire-server.tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| spire-server.tools.kubectl.image.tag | string | `""` | Overrides the image tag |
+| spire-server.tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | spire-server.topologySpreadConstraints | list | `[]` |  |
 | spire-server.tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
 | spire-server.tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
@@ -400,7 +400,12 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.tornjak.startupProbe.successThreshold | int | `1` |  |
 | spire-server.tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | spire-server.trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| spire-server.upstreamAuthority.certManager.createCA | bool | `false` | Creates a Cert-manager CA |
+| spire-server.upstreamAuthority.certManager.ca.create | bool | `true` | Creates a Cert-manager CA |
+| spire-server.upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
+| spire-server.upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |
+| spire-server.upstreamAuthority.certManager.ca.privateKey.rotationPolicy | string | `""` |  |
+| spire-server.upstreamAuthority.certManager.ca.privateKey.size | int | `256` |  |
+| spire-server.upstreamAuthority.certManager.ca.renewBefore | string | `""` | How long to wait before renewing the CA |
 | spire-server.upstreamAuthority.certManager.enabled | bool | `false` |  |
 | spire-server.upstreamAuthority.certManager.issuer_group | string | `"cert-manager.io"` |  |
 | spire-server.upstreamAuthority.certManager.issuer_kind | string | `"Issuer"` |  |
@@ -408,7 +413,6 @@ Now you can interact with the Spire agent socket from your own application. The 
 | spire-server.upstreamAuthority.certManager.kube_config_file | string | `""` |  |
 | spire-server.upstreamAuthority.certManager.namespace | string | `""` | Specify to use a namespace other then the one the chart is installed into |
 | spire-server.upstreamAuthority.certManager.rbac.create | bool | `true` |  |
-| spire-server.upstreamAuthority.certManager.signedSpec | object | `{}` | See https://cert-manager.io/docs/configuration/ca/ and other options to configure a CA. By default this chart will deploy a selfsigned CA. |
 | spire-server.upstreamAuthority.disk.enabled | bool | `false` |  |
 | spire-server.upstreamAuthority.disk.secret.create | bool | `true` | If disabled requires you to create a secret with the given keys (certificate, key and optional bundle) yourself. |
 | spire-server.upstreamAuthority.disk.secret.data | object | `{"bundle":"","certificate":"","key":""}` | If secret creation is enabled, will create a secret with following certificate info |

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -52,11 +52,6 @@ A Helm chart to install the SPIRE server.
 | controllerManager.service.port | int | `443` |  |
 | controllerManager.service.type | string | `"ClusterIP"` |  |
 | controllerManager.validatingWebhookConfiguration.failurePolicy | string | `"Fail"` |  |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.tag | string | `""` | Overrides the image tag |
-| controllerManager.validatingWebhookConfiguration.upgradeHook.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | dataStore.sql.databaseName | string | `"spire"` | Only used by "postgres" or "mysql" |
 | dataStore.sql.databaseType | string | `"sqlite3"` | Other supported databases are "postgres" and "mysql" |
 | dataStore.sql.host | string | `""` | Only used by "postgres" or "mysql" |
@@ -128,6 +123,11 @@ A Helm chart to install the SPIRE server.
 | telemetry.prometheus.podMonitor.labels | object | `{}` |  |
 | telemetry.prometheus.podMonitor.namespace | string | `""` | Override where to install the podMonitor, if not set will use the same namespace as the spire-server |
 | tolerations | list | `[]` |  |
+| tools.kubectl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| tools.kubectl.image.registry | string | `"docker.io"` | The OCI registry to pull the image from |
+| tools.kubectl.image.repository | string | `"rancher/kubectl"` | The repository within the registry |
+| tools.kubectl.image.tag | string | `""` | Overrides the image tag |
+| tools.kubectl.image.version | string | `""` | This value is deprecated in favor of tag. (Will be removed in a future release) |
 | topologySpreadConstraints | list | `[]` |  |
 | tornjak.config.dataStore | object | `{"driver":"sqlite3","file":"/run/spire/data/tornjak.sqlite3"}` | persistent DB for storing Tornjak specific information |
 | tornjak.enabled | bool | `false` | Deploys Tornjak API (backend) (Not for production) |
@@ -146,7 +146,12 @@ A Helm chart to install the SPIRE server.
 | tornjak.startupProbe.successThreshold | int | `1` |  |
 | tornjak.startupProbe.timeoutSeconds | int | `5` |  |
 | trustDomain | string | `"example.org"` | Set the trust domain to be used for the SPIFFE identifiers |
-| upstreamAuthority.certManager.createCA | bool | `false` | Creates a Cert-manager CA |
+| upstreamAuthority.certManager.ca.create | bool | `true` | Creates a Cert-manager CA |
+| upstreamAuthority.certManager.ca.duration | string | `"87600h"` | Duration of the CA. Defaults to 10 years. |
+| upstreamAuthority.certManager.ca.privateKey.algorithm | string | `"ECDSA"` |  |
+| upstreamAuthority.certManager.ca.privateKey.rotationPolicy | string | `""` |  |
+| upstreamAuthority.certManager.ca.privateKey.size | int | `256` |  |
+| upstreamAuthority.certManager.ca.renewBefore | string | `""` | How long to wait before renewing the CA |
 | upstreamAuthority.certManager.enabled | bool | `false` |  |
 | upstreamAuthority.certManager.issuer_group | string | `"cert-manager.io"` |  |
 | upstreamAuthority.certManager.issuer_kind | string | `"Issuer"` |  |
@@ -154,7 +159,6 @@ A Helm chart to install the SPIRE server.
 | upstreamAuthority.certManager.kube_config_file | string | `""` |  |
 | upstreamAuthority.certManager.namespace | string | `""` | Specify to use a namespace other then the one the chart is installed into |
 | upstreamAuthority.certManager.rbac.create | bool | `true` |  |
-| upstreamAuthority.certManager.signedSpec | object | `{}` | See https://cert-manager.io/docs/configuration/ca/ and other options to configure a CA. By default this chart will deploy a selfsigned CA. |
 | upstreamAuthority.disk.enabled | bool | `false` |  |
 | upstreamAuthority.disk.secret.create | bool | `true` | If disabled requires you to create a secret with the given keys (certificate, key and optional bundle) yourself. |
 | upstreamAuthority.disk.secret.data | object | `{"bundle":"","certificate":"","key":""}` | If secret creation is enabled, will create a secret with following certificate info |

--- a/charts/spire/charts/spire-server/templates/issuer.yaml
+++ b/charts/spire/charts/spire-server/templates/issuer.yaml
@@ -1,21 +1,17 @@
 {{- with .Values.upstreamAuthority.certManager }}
-{{ if and .enabled .createCA }}
+{{ if and .enabled .ca.create }}
 {{/*
 Configuring CA Issuer: https://cert-manager.io/docs/configuration/ca/
 */}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "spire-server.fullname" $ }}-signed
+  name: {{ include "spire-server.fullname" $ }}-selfsigned
   namespace: {{ include "spire-server.namespace" $ }}
   labels:
     {{- include "spire-server.labels" $ | nindent 4}}
 spec:
-{{- if .signedSpec }}
-  {{- toYaml .signedSpec | nindent 4 }}
-{{- else }}
   selfSigned: {}
-{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -26,11 +22,23 @@ spec:
   isCA: true
   commonName: {{ $.Values.ca_subject.common_name }}
   secretName: {{ include "spire-server.fullname" $ }}-ca-keys
+  duration: {{ $.Values.upstreamAuthority.certManager.ca.duration }}
+  subject:
+    countries:
+      - {{ $.Values.ca_subject.country }}
+    organizations:
+      - {{ $.Values.ca_subject.organization }}
   privateKey:
-    algorithm: ECDSA
-    size: 256
+    algorithm: {{ $.Values.upstreamAuthority.certManager.ca.privateKey.algorithm }}
+    size: {{ $.Values.upstreamAuthority.certManager.ca.privateKey.size }}
+    {{- with $.Values.upstreamAuthority.certManager.ca.privateKey.rotationPolicy }}
+    rotationPolicy: {{ . }}
+    {{- end }}
+  {{- with $.Values.upstreamAuthority.certManager.ca.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
   issuerRef:
-    name: {{ include "spire-server.fullname" $ }}-signed
+    name: {{ include "spire-server.fullname" $ }}-selfsigned
     kind: Issuer
     group: cert-manager.io
 ---

--- a/charts/spire/charts/spire-server/templates/post-install-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-install-hook.yaml
@@ -63,7 +63,7 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/post-upgrade-hook.yaml
@@ -63,7 +63,7 @@ spec:
       - name: post-upgrade-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
+++ b/charts/spire/charts/spire-server/templates/pre-upgrade-hook.yaml
@@ -63,7 +63,7 @@ spec:
       - name: post-install-job
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.controllerManager.validatingWebhookConfiguration.upgradeHook.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
+        image: {{ template "spire-server.kubectl-image" (dict "appVersion" $.Chart.AppVersion "image" .Values.tools.kubectl.image "global" .Values.global "KubeVersion" .Capabilities.KubeVersion.Version) }}
         args:
           - patch
           - validatingwebhookconfiguration

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -193,11 +193,17 @@ upstreamAuthority:
     namespace: ""
     kube_config_file: ""
 
-    # -- Creates a Cert-manager CA
-    createCA: false
-    # -- See https://cert-manager.io/docs/configuration/ca/ and other options to configure a CA. By default this chart will deploy a selfsigned CA.
-    signedSpec: {}
-
+    ca:
+      # -- Creates a Cert-manager CA
+      create: true
+      # -- Duration of the CA. Defaults to 10 years.
+      duration:  87600h
+      privateKey:
+        algorithm: ECDSA
+        size: 256
+        rotationPolicy: ""
+      # -- How long to wait before renewing the CA
+      renewBefore: ""
   spire:
     enabled: false
     server:
@@ -273,18 +279,20 @@ controllerManager:
 
   validatingWebhookConfiguration:
     failurePolicy: Fail
-    upgradeHook:
-      image:
-        # -- The OCI registry to pull the image from
-        registry: docker.io
-        # -- The repository within the registry
-        repository: rancher/kubectl
-        # -- The image pull policy
-        pullPolicy: IfNotPresent
-        # -- This value is deprecated in favor of tag. (Will be removed in a future release)
-        version: ""
-        # -- Overrides the image tag
-        tag: ""
+
+tools:
+  kubectl:
+    image:
+      # -- The OCI registry to pull the image from
+      registry: docker.io
+      # -- The repository within the registry
+      repository: rancher/kubectl
+      # -- The image pull policy
+      pullPolicy: IfNotPresent
+      # -- This value is deprecated in favor of tag. (Will be removed in a future release)
+      version: ""
+      # -- Overrides the image tag
+      tag: ""
 
 telemetry:
   prometheus:


### PR DESCRIPTION
This pr adds fixes for the remaining identified issues and undoes one feature in order to try and get things merged faster.

1. It makes the CA always self signed. I read through some of the documentation on how to setup a CA with the AWS Private CA plugin and if I understand it correctly, you don't need the signed issuer or the Certificate in that case. So that feature needs significant rework. Just hardcoding for now in the name of expediency
2. Switch the kubectl image to a more supportable place.
3. Add missing values for setting up a CA.
4. Default the CA on, as it makes it easier to kick the tires.
